### PR TITLE
Relaxed brakeman dependency

### DIFF
--- a/pronto-brakeman.gemspec
+++ b/pronto-brakeman.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'pronto', '~> 0.3'
-  s.add_runtime_dependency 'brakeman', '~> 2.6', '>= 2.6.0'
+  s.add_runtime_dependency 'brakeman', '>= 2.6.0'
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its', '~> 1.0'


### PR DESCRIPTION
This lets pronto-brakeman work with Brakeman 3.0.0.