### PR TITLE
Filter out warnings ignored by brakeman

### DIFF
--- a/lib/pronto/brakeman.rb
+++ b/lib/pronto/brakeman.rb
@@ -22,7 +22,7 @@ module Pronto
     end
 
     def messages_for(ruby_patches, output)
-      output.checks.all_warnings.map do |warning|
+      output.filtered_warnings.map do |warning|
         patch = patch_for_warning(ruby_patches, warning)
 
         if patch


### PR DESCRIPTION
Ignore the warnings filtered out by brakeman by specifying in `config/brakeman.ignore` or any file given through options.